### PR TITLE
Basic error handling for en– and decoding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,18 +5,20 @@ fn scale(n: f64, factor: i32) -> i64 {
     scaled.round() as i64
 }
 
-fn encode(current: f64, previous: f64, factor: i32) -> String {
+fn encode(current: f64, previous: f64, factor: i32) -> Result<String, String> {
     let mut coordinate = (scale(current, factor) - scale(previous, factor)) << 1;
     if (current - previous) < 0.0 {
         coordinate = !coordinate;
     }
     let mut output: String = "".to_string();
     while coordinate >= 0x20 {
-        output.push(char::from_u32(((0x20 | (coordinate & 0x1f)) + 63) as u32).unwrap());
+        let from_char = try!(char::from_u32(((0x20 | (coordinate & 0x1f)) + 63) as u32)
+            .ok_or("Couldn't convert character"));
+        output.push(from_char);
         coordinate >>= 5;
     }
-    output.push(char::from_u32((coordinate  + 63) as u32).unwrap());
-    output
+    output.push(char::from_u32((coordinate + 63) as u32).unwrap());
+    Ok(output)
 }
 
 /// Encodes a Google Encoded Polyline.
@@ -26,26 +28,26 @@ fn encode(current: f64, previous: f64, factor: i32) -> String {
 /// ```
 /// use polyline;
 ///
-///	let coords = vec![[1.0, 2.0], [3.0, 4.0]];
+/// 	let coords = vec![[1.0, 2.0], [3.0, 4.0]];
 /// let encodedPolyline = polyline::encode_coordinates(&coords, 5);
 /// ```
-pub fn encode_coordinates(coordinates: &Vec<[f64; 2]>, precision: u32) -> String {
+pub fn encode_coordinates(coordinates: &Vec<[f64; 2]>, precision: u32) -> Result<String, String> {
     if coordinates.len() == 0 {
-        return "".to_string();
+        return Ok("".to_string());
     }
     let base: i32 = 10;
     let factor: i32 = base.pow(precision);
 
-    let mut output = encode(coordinates[0][0], 0.0, factor) +
-        &encode(coordinates[0][1], 0.0, factor);
+    let mut output = try!(encode(coordinates[0][0], 0.0, factor)) +
+                     &try!(encode(coordinates[0][1], 0.0, factor));
 
     for i in 1..coordinates.len() {
         let a = coordinates[i];
         let b = coordinates[i - 1];
-        output = output + &encode(a[0], b[0], factor);
-        output = output + &encode(a[1], b[1], factor);
+        output = output + &try!(encode(a[0], b[0], factor));
+        output = output + &try!(encode(a[1], b[1], factor));
     }
-    output
+    Ok(output)
 }
 
 
@@ -58,7 +60,7 @@ pub fn encode_coordinates(coordinates: &Vec<[f64; 2]>, precision: u32) -> String
 ///
 /// let decodedPolyline = polyline::decode_polyline("_p~iF~ps|U_ulLnnqC_mqNvxq`@".to_string(), 5);
 /// ```
-pub fn decode_polyline(str: String, precision: u32) -> Vec<[f64; 2]> {
+pub fn decode_polyline(str: String, precision: u32) -> Result<Vec<[f64; 2]>, String> {
     let mut index = 0;
     let mut lat: i64 = 0;
     let mut lng: i64 = 0;
@@ -73,12 +75,14 @@ pub fn decode_polyline(str: String, precision: u32) -> Vec<[f64; 2]> {
         let mut byte;
 
         while {
-            byte = (str.chars().nth(index).unwrap() as u64) - 63;
+            let at_index = try!(str.chars().nth(index).ok_or("Couldn't decode Polyline"));
+            byte = at_index as u64 - 63;
             index = index + 1;
             result |= (byte & 0x1f) << shift;
             shift += 5;
             byte >= 0x20
-        } { }
+        } {
+        }
 
         let latitude_change: i64 = if (result & 1) > 0 {
             !(result >> 1)
@@ -95,7 +99,8 @@ pub fn decode_polyline(str: String, precision: u32) -> Vec<[f64; 2]> {
             result |= (byte & 0x1f) << shift;
             shift += 5;
             byte >= 0x20
-        } { }
+        } {
+        }
 
         let longitude_change: i64 = if (result & 1) > 0 {
             !(result >> 1)
@@ -106,13 +111,10 @@ pub fn decode_polyline(str: String, precision: u32) -> Vec<[f64; 2]> {
         lat += latitude_change;
         lng += longitude_change;
 
-        coordinates.push([
-			lat as f64 / factor as f64,
-			lng as f64 / factor as f64
-		]);
+        coordinates.push([lat as f64 / factor as f64, lng as f64 / factor as f64]);
     }
 
-    coordinates
+    Ok(coordinates)
 }
 
 #[cfg(test)]
@@ -123,24 +125,24 @@ mod tests {
 
     struct TestCase {
         input: Vec<[f64; 2]>,
-        output: &'static str
+        output: &'static str,
     }
 
     #[test]
     fn it_works() {
-        let test_cases = vec![
-            TestCase {
-                input:  vec![[1.0, 2.0], [3.0, 4.0]],
-                output: "_ibE_seK_seK_seK"
-            },
-            TestCase {
-                input:  vec![[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]],
-                output: "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
-            }
-        ];
+        let test_cases = vec![TestCase {
+                                  input: vec![[1.0, 2.0], [3.0, 4.0]],
+                                  output: "_ibE_seK_seK_seK",
+                              },
+                              TestCase {
+                                  input: vec![[38.5, -120.2], [40.7, -120.95], [43.252, -126.453]],
+                                  output: "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+                              }];
         for test_case in test_cases {
-            assert_eq!(encode_coordinates(&test_case.input, 5), test_case.output);
-            assert_eq!(decode_polyline(test_case.output.to_string(), 5), test_case.input);
+            assert_eq!(encode_coordinates(&test_case.input, 5).unwrap(),
+                       test_case.output);
+            assert_eq!(decode_polyline(test_case.output.to_string(), 5).unwrap(),
+                       test_case.input);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ fn encode(current: f64, previous: f64, factor: i32) -> Result<String, String> {
 /// let encodedPolyline = polyline::encode_coordinates(&coords, 5);
 /// ```
 pub fn encode_coordinates(coordinates: &Vec<[f64; 2]>, precision: u32) -> Result<String, String> {
-    if coordinates.len() == 0 {
+    if coordinates.is_empty() {
         return Ok("".to_string());
     }
     let base: i32 = 10;
@@ -41,7 +41,7 @@ pub fn encode_coordinates(coordinates: &Vec<[f64; 2]>, precision: u32) -> Result
     let mut output = try!(encode(coordinates[0][0], 0.0, factor)) +
                      &try!(encode(coordinates[0][1], 0.0, factor));
 
-    for i in 1..coordinates.len() {
+    for (i, _) in coordinates.iter().enumerate().skip(1) {
         let a = coordinates[i];
         let b = coordinates[i - 1];
         output = output + &try!(encode(a[0], b[0], factor));
@@ -77,7 +77,7 @@ pub fn decode_polyline(str: String, precision: u32) -> Result<Vec<[f64; 2]>, Str
         while {
             let at_index = try!(str.chars().nth(index).ok_or("Couldn't decode Polyline"));
             byte = at_index as u64 - 63;
-            index = index + 1;
+            index += 1;
             result |= (byte & 0x1f) << shift;
             shift += 5;
             byte >= 0x20
@@ -95,7 +95,7 @@ pub fn decode_polyline(str: String, precision: u32) -> Result<Vec<[f64; 2]>, Str
 
         while {
             byte = (str.chars().nth(index).unwrap() as u64) - 63;
-            index = index + 1;
+            index += 1;
             result |= (byte & 0x1f) << shift;
             shift += 5;
             byte >= 0x20


### PR DESCRIPTION
`encode_coordinates()` and `decode_polyline()` now cope with the
possibility that a u32 can't be encoded as a char, or that your `.nth()`
operation could fail because `index` is longer than `str`
(the latter is unlikely, but here we are).

This also means that your public functions now return `Result` types,
which allows their consumers to be a bit more flexible.